### PR TITLE
add and fix: sharing buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ summarylength = 200
   profile = "世知辛い世の中を静かに暮らしたい<br><a href=\"https://nagatani.me/\" target=\"_blank\">https://nagatani.me/</a>"
   displayauthor = false
   DateForm = "2006-01-02"
+  sharingicons = true
 
 [params.highlight]
 theme = "monokai-sublime"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -23,6 +23,10 @@
         {{ .Content }}
       </div>
     </article>
+
+    {{ if (ne ($.Param "sharingicons") false) }}
+    {{ partial "sharing.html" . }}
+    {{ end }}
   </div>
 </main>
 

--- a/layouts/partials/sharing.html
+++ b/layouts/partials/sharing.html
@@ -1,8 +1,5 @@
-    <div class="nav-left">
-    <a class="nav-item" href="https://www.facebook.com/sharer/sharer.php?u={{ .Permalink }}" title="Share on Facebook" target="_blank"><span class="fa fa-facebook fa-2x" aria-hidden="true"></span></a>
-    <a class="nav-item" href="https://plus.google.com/share?url={{ .Permalink }}" title="Share on Google+" target="_blank"><span class="fa fa-google-plus fa-2x" aria-hidden="true"></span></a>
-    <a class="nav-item" href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ .Permalink }}" title="Share on LinkedIn" target="_blank"><span class="fa fa-linkedin fa-2x" aria-hidden="true"></span></a>
-    <a class="nav-item" href="https://twitter.com/home?status={{ .Title }} - {{ .Permalink }}" title="Tweet this" target="_blank"><span class="fa fa-twitter fa-2x"></span></a>
-    <a class="nav-item" href="http://www.reddit.com/submit?url={{ .Permalink }}&title={{ .Title }}" title="Share on Reddit" target="_blank"><span class="fa fa-reddit-alien fa-2x" aria-hidden="true"></span></a>
-    <!-- <a class="nav-item" href="mailto:?subject={{ .Title }}&body={{ .Content }}" title="Share via Email" target="_blank"><span class="fa fa-envelope fa-2x" aria-hidden="true"></span></a> -->
-    </div>
+<aside class="share">
+  <a class="twitter" href="https://twitter.com/intent/tweet?url={{ .Permalink }}&text={{ .Title }}&tw_p=tweetbutton" onclick="window.open(this.href, 'shareWindow', 'width=550, height=350, menubar=no, toolbar=no, scrollbars=yes'); return false;"><i class="fab fa-twitter"></i></a>
+  <a class="facebook" href="https://www.facebook.com/sharer.php?u={{ .Permalink }}&t={{ .Title }}" onclick="window.open(this.href, 'shareWindow', 'width=550, height=350, menubar=no, toolbar=no, scrollbars=yes'); return false;"><i class="fab fa-facebook"></i></a>
+  <a class="googleplus" href="https://plus.google.com/share?url={{ .Permalink }}" onclick="window.open(this.href, 'shareWindow', 'width=550, height=350, menubar=no, toolbar=no, scrollbars=yes'); return false;"><i class="fab fa-google-plus"></i></a>
+</aside>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -415,3 +415,27 @@ hr {
 .footnotes ol {
   margin-top: 1rem;
 }
+
+/* Share */
+.share {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+.share a {
+  display: block;
+  flex: 1;
+  text-align: center;
+  border: 1px solid #eee;
+  font-size: 1.5rem;
+  line-height: 1;
+  height: 2em;
+  padding: .5em;
+}
+.share a:hover {
+  background-color: #00a381;
+  color: #f0f0f0;
+}
+.share .twitter:hover { background-color: #008DDE; }
+.share .facebook:hover { background-color: #2e4a88; }
+.share .googleplus:hover { background-color: #CC3622; }


### PR DESCRIPTION
記事個別にシェアボタンを追加できるようにした。

READMEを参考にして、`config.toml`に[params]配下に`sharingicons = true`を差し込めばOK。

または、記事個別のメタ情報のところに以下の一文を入れるのでもOK。
```
sharingicons: true
```

逆に記事個別でシェアボタンいらん場合は、`false`を設定すればいい。
